### PR TITLE
Herokuでのデプロイ時Precompiling assets failed.と表示される

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
#57 
Precompiling assets failed.と表示されるエラーを解決する