### PR TITLE
[1pt] 本番環境で今日出来たことを作成後の確認ページで今日出来たことの編集が出来ない

### DIFF
--- a/app/javascript/success_records.js
+++ b/app/javascript/success_records.js
@@ -42,7 +42,7 @@ document.addEventListener("turbolinks:load", function() {
         'success_body': body
       }
   
-      fetch(`http://localhost:3000/success_records/${successRecordId}`, {
+      fetch(`/success_records/${successRecordId}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json"

--- a/spec/system/success_records_spec.rb
+++ b/spec/system/success_records_spec.rb
@@ -8,7 +8,7 @@ feature "SuccessRecords", js: true, type: :feature do
     login_as(@user, scope: :user)
   end
 
-  scenario "creatting a success record" do
+  scenario "creating a success record" do
     @success_record = build(:success_record, user: @user)
 
     visit root_path
@@ -17,6 +17,23 @@ feature "SuccessRecords", js: true, type: :feature do
     click_on "登録する"
 
     assert_text "今日出来たことが作成されました。"
+    click_on "OK"
+  end
+
+  scenario "editing a success record after creating it" do
+    @success_record = build(:success_record, user: @user)
+
+    visit root_path
+    click_on "今日出来たことを記録する", match: :first
+    fill_in "今日出来たこと", with: @success_record.success_body
+    click_on "登録する"
+
+    assert_text "今日出来たことが作成されました。"
+    click_on "編集"
+    fill_in "内容", with: "test"
+    click_on "更新"
+
+    expect(page).to have_content "test"
     click_on "OK"
   end
 


### PR DESCRIPTION
#66

編集後、更新ボタンをクリックすると内容を入力してくださいと表示され更新できない
https://gyazo.com/4d5bfce685c5e525ccb718cc2718ba32